### PR TITLE
Drop the worker context and downgrade back to opentelemetry 0.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+- Drop the `worker::Context` on `DatadogPipelineBuilder::install`
+- Bridge `SpanProcessor` to async through `spawn_local` on `force_flush` and `on_end`
+- Downgrade opentelemetry to `v0.17` due to memory access errors on cloudflare workers
+
 ## [0.9.0]
 
 ## [0.8.0]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 surf-client = ["surf", "opentelemetry-http/surf"]
 
 [dependencies]
+async-trait = "0.1"
 futures-channel = { version = "0.3" }
 futures-util = "0.3"
-opentelemetry = { version = "0.18", features = ["trace"] }
-opentelemetry-http = { version = "0.7" }
-opentelemetry-semantic-conventions = { version = "0.10" }
+# don't bump to 0.18, it leads to memory access out of bounds in cloudflare workers
+opentelemetry = { version = "0.17", features = ["trace"] }
+opentelemetry-http = { version = "0.6" }
+opentelemetry-semantic-conventions = { version = "0.9" }
 rmp = "0.8"
 surf = { version = "2", default-features = false, optional = true }
 thiserror = "1.0"
@@ -50,4 +52,4 @@ base64 = "0.13"
 bytes = "1"
 futures-util = { version = "0.3", features = ["io"] }
 isahc = "1"
-opentelemetry = { version = "0.18", features = ["trace", "testing"] }
+opentelemetry = { version = "0.17", features = ["trace", "testing"] }


### PR DESCRIPTION
Drop the worker context dependency and bridge through spawn_local.

Go back to opentelemetry 0.17 due to memory access out of bounds in cloudflare workers