### PR TITLE
Async export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## [Unreleased]
 
-## [1.0.0]
+-   Add an extension that provides an async `force_flush`
+-   Replace the `spawn_local` approach with the async `force_flush`
+-   Yank `1.0.0` release
+
+## [1.0.0] (*YANKED*)
 
 -   Drop the `worker::Context` on `DatadogPipelineBuilder::install`
 -   Bridge `SpanProcessor` to async through `spawn_local` on `force_flush` and `on_end`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,9 @@ lazy_static = "1"
 worker = "0.0.12"
 prost = { version = "0.11", features = ["std"] }
 
+[patch.crates-io]
+opentelemetry = { git = "https://github.com/hfgbarrigas/opentelemetry-rust.git", branch = "v0.17.0-patch" }
+
 [build-dependencies]
 prost-build = { version = "0.11" }
 tonic-build = { version = "0.8", features = ["transport", "prost"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,5 +293,8 @@ mod propagator {
     }
 }
 
-pub use exporter::{new_pipeline, DatadogExporter, DatadogPipelineBuilder, Error};
+pub use exporter::{
+    new_pipeline, DatadogExporter, DatadogPipelineBuilder, Error, SpanProcessExt,
+    WASMWorkerSpanProcessor,
+};
 pub use propagator::DatadogPropagator;


### PR DESCRIPTION
This PR adds the ability to export asynchronously.

It uses an extension trait with an async `force_flush`. This replaces the previous approach of using a `spawn_local` because Cloudflare doesn't run anything in the background when the request has finished.

Additionally, it uses a patched version of `opentelemetry:v0.17.0` that adds `fn as_any(&self) -> &dyn Any` to `SpanProcessor` for downcasting purposes.