### PR TITLE
Swap the `surf` client out for `reqwest` and drop unused dependencies (including worker)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --features surf-client
+          args: --features reqwest-client
   build_and_test:
     name: Build CI
     runs-on: ubuntu-latest
@@ -35,8 +35,8 @@ jobs:
           toolchain: stable
           components: clippy
           profile: minimal
-      - name: Check with surf-client
-        run: cargo check --features surf-client
+      - name: Check with reqwest-client
+        run: cargo check --features reqwest-client
       - name: Clean
         run: cargo clean
 

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -63,7 +63,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: publish
-        args: --features surf-client
+        args: --features reqwest-client
 
     - name: Update deployment status
       uses: actions/github-script@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+-   Drop unused dependencies (including the worker crate).
+-   Switch to using reqwest as the HTTP client.
+
 ## [0.10.0]
 
 -   Add an extension that provides an async `force_flush`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,19 +22,16 @@ reqwest-client = ["reqwest", "opentelemetry-http/reqwest"]
 
 [dependencies]
 async-trait = "0.1"
-futures-channel = { version = "0.3" }
 futures-util = "0.3"
 # don't bump to 0.18, it leads to memory access out of bounds in cloudflare workers
 opentelemetry = { version = "0.17", package = "opentelemetry-spanprocessor-any", features = ["trace"] }
 opentelemetry-http = { version = "0.6" }
 opentelemetry-semantic-conventions = { version = "0.9" }
-rmp = "0.8"
 reqwest = { version = "0.11", default-features = false, optional = true }
 thiserror = "1.0"
 itertools = "0.10"
 http = "0.2"
 lazy_static = "1"
-worker = "0.0.13"
 prost = { version = "0.11", features = ["std"] }
 
 [build-dependencies]
@@ -48,8 +45,5 @@ reqwest = { version = "0.11", default-features = false }
 reqwest = { version = "0.11", default-features = false, features = ["__rustls"] }
 
 [dev-dependencies]
-base64 = "0.13"
-bytes = "1"
 futures-util = { version = "0.3", features = ["io"] }
-isahc = "1"
 opentelemetry = { version = "0.17", package = "opentelemetry-spanprocessor-any", features = ["trace", "testing"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-surf-client = ["surf", "opentelemetry-http/surf"]
+reqwest-client = ["reqwest", "opentelemetry-http/reqwest"]
 
 [dependencies]
 async-trait = "0.1"
@@ -29,7 +29,7 @@ opentelemetry = { version = "0.17", package = "opentelemetry-spanprocessor-any",
 opentelemetry-http = { version = "0.6" }
 opentelemetry-semantic-conventions = { version = "0.9" }
 rmp = "0.8"
-surf = { version = "2", default-features = false, optional = true }
+reqwest = { version = "0.11", default-features = false, optional = true }
 thiserror = "1.0"
 itertools = "0.10"
 http = "0.2"
@@ -42,10 +42,10 @@ prost-build = { version = "0.11" }
 tonic-build = { version = "0.8", features = ["transport", "prost"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-surf = { version = "2", default-features = false, features = ["wasm-client"] }
+reqwest = { version = "0.11", default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-surf = { version = "2", default-features = false, features = ["h1-client-rustls"] }
+reqwest = { version = "0.11", default-features = false, features = ["__rustls"] }
 
 [dev-dependencies]
 base64 = "0.13"

--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ Based on [`opentelemetry-datadog`](https://github.com/open-telemetry/opentelemet
 
 `opentelemetry-datadog-cloudflare` supports following features:
 
-- `surf-client`: use `surf` http client to send spans.
+- `reqwest-client`: use the `reqwest` HTTP client to send spans.
 

--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,7 @@ fn main() {
     println!("cargo:rerun-if-changed=proto/google/pubsub/v1/pubsub.proto");
 
     let mut prost_build = prost_build::Config::new();
-    prost_build.btree_map(&["."]);
+    prost_build.btree_map(["."]);
 
     tonic_build::configure()
         .compile_with_config(

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.62"
+channel = "1.68"
 targets = [
     "wasm32-unknown-unknown",     # Cloudflare Workers
 ]

--- a/src/exporter/mod.rs
+++ b/src/exporter/mod.rs
@@ -417,9 +417,7 @@ impl DatadogPipelineBuilder {
 fn group_into_traces(spans: Vec<SpanData>) -> Vec<Vec<SpanData>> {
     spans
         .into_iter()
-        .into_group_map_by(|span_data| span_data.span_context.trace_id())
-        .into_iter()
-        .map(|(_, trace)| trace)
+        .into_group_map_by(|span_data| span_data.span_context.trace_id()).into_values()
         .collect()
 }
 

--- a/src/exporter/mod.rs
+++ b/src/exporter/mod.rs
@@ -28,6 +28,9 @@ use std::time::{Duration, SystemTime};
 
 use crate::dd_proto;
 
+#[cfg(not(feature = "reqwest-client"))]
+use reqwest as _;
+
 const DEFAULT_SITE_ENDPOINT: &str = "https://trace.agent.datadoghq.eu/";
 const DEFAULT_DD_TRACES_PATH: &str = "api/v0.2/traces";
 const DEFAULT_DD_CONTENT_TYPE: &str = "application/x-protobuf";

--- a/src/exporter/mod.rs
+++ b/src/exporter/mod.rs
@@ -114,10 +114,10 @@ impl Default for DatadogPipelineBuilder {
             agent_endpoint: DEFAULT_SITE_ENDPOINT.to_string(),
             trace_config: None,
             api_key: None,
-            #[cfg(not(feature = "surf-client"))]
+            #[cfg(not(feature = "reqwest-client"))]
             client: None,
-            #[cfg(feature = "surf-client")]
-            client: Some(Arc::new(surf::Client::new())),
+            #[cfg(feature = "reqwest-client")]
+            client: Some(Arc::new(reqwest::Client::new())),
             env: None,
             tags: None,
             host_name: None,
@@ -161,7 +161,7 @@ impl SpanProcessExt for WASMWorkerSpanProcessor {
                 Ok(l) => l,
                 Err(e) => {
                     global::handle_error(e);
-                    return Err(TraceError::from("unable to obtain lock to flush"))
+                    return Err(TraceError::from("unable to obtain lock to flush"));
                 }
             };
 
@@ -198,7 +198,9 @@ impl SpanProcessor for WASMWorkerSpanProcessor {
     }
 
     fn force_flush(&self) -> TraceResult<()> {
-        Err(TraceError::from("Sync flush is not supported, use `force_flush` from `SpanProcessExt`"))
+        Err(TraceError::from(
+            "Sync flush is not supported, use `force_flush` from `SpanProcessExt`",
+        ))
     }
 
     fn shutdown(&mut self) -> TraceResult<()> {
@@ -234,7 +236,9 @@ impl DatadogPipelineBuilder {
                 cfg.resource = cfg.resource.map(|r| {
                     let without_service_name = r
                         .iter()
-                        .filter(|(k, _v)| **k != Key::new(semcov::resource::SERVICE_NAME.to_string()))
+                        .filter(|(k, _v)| {
+                            **k != Key::new(semcov::resource::SERVICE_NAME.to_string())
+                        })
                         .map(|(k, v)| KeyValue::new(k.clone(), v.clone()))
                         .collect::<Vec<KeyValue>>();
                     Arc::new(Resource::new(without_service_name))

--- a/src/exporter/model/mod.rs
+++ b/src/exporter/model/mod.rs
@@ -7,7 +7,7 @@ pub enum Error {
     #[error("message pack error")]
     MessagePackError,
     /// No http client founded. User should provide one or enable features
-    #[error("http client must be set, users can enable reqwest or surf feature to use http client implementation within create")]
+    #[error("http client must be set, users can enable reqwest or reqwest feature to use http client implementation within create")]
     NoHttpClient,
     /// Http requests failed with following errors
     #[error(transparent)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //!
 //! Users can choose appropriate http clients to align with their runtime.
 //!
-//! Based on the feature enabled. The only client available is surf, feel free to implement
+//! Based on the feature enabled. The only client available is reqwest, feel free to implement
 //! other http clients.
 //!
 //! Note that async http clients may need specific runtime otherwise it will panic. User should make

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,9 @@
 //! sure the http client is running in appropriate runime.
 //!
 //! Users can always use their own http clients by implementing `HttpClient` trait.
-//!
+
+#![deny(unused_crate_dependencies)]
+
 pub(crate) mod dd_proto {
     include!(concat!(env!("OUT_DIR"), "/dd_trace.rs"));
 }


### PR DESCRIPTION
What this PR does / why we need it:

Which issue(s) this PR fixes:

- Switches to using the `reqwest` client.

